### PR TITLE
Add missing pipeline symbol `\` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Add the repository and install motus:
 ```bash
 # Download and install the repository's GPG key
 curl -fsSL https://oleiade.github.io/deb/oleiade-archive-keyring.gpg | \
-gpg --dearmor \
+gpg --dearmor | \
 sudo tee /usr/share/keyrings/oleiade-archive-keyring.gpg > /dev/null
 
 # Add the repository to your system's sources


### PR DESCRIPTION
A pipline symbol is missing which leads installation failure.


### Actual Behavior
```
$ curl -fsSL https://oleiade.github.io/deb/oleiade-archive-keyring.gpg | \
> gpg --dearmor \
> sudo tee /usr/share/keyrings/oleiade-archive-keyring.gpg > /dev/null
usage: gpg [options] --dearmor [file]
(23) Failed writing body
```

### Expected
```
$ curl -fsSL https://oleiade.github.io/deb/oleiade-archive-keyring.gpg | \
> gpg --dearmor | \
> sudo tee /usr/share/keyrings/oleiade-archive-keyring.gpg > /dev/null
```
_no output_