### PR TITLE
feat: introduce deactivable clipboard cargo feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,20 @@ WINDOWS_TARGETS = x86_64-pc-windows-gnu \
 # Rule for building all targets
 release: linux macos wasm
 
+# Rule for building all headless targets (without clipboard)
+release-headless: linux-headless macos-headless
+
 # Rule for building Linux targets, Debian, and RPM packages
 linux: check_cross check_linux_crosscompilation_on_macos $(LINUX_TARGETS) $(addprefix deb-, $(LINUX_TARGETS))
 
+# Rule for building Linux targets without clipboard support
+linux-headless: check_cross check_linux_crosscompilation_on_macos $(addprefix headless-, $(LINUX_TARGETS))
+
 # Rule for building macOS targets
 macos: check_cargo check_toolchain check_cross $(MACOS_TARGETS)
+
+# Rule for building macOS targets without clipboard support
+macos-headless: check_cargo check_toolchain check_cross $(addprefix headless-, $(MACOS_TARGETS))
 
 # Rule for building wasm code
 wasm: check_wasm_pack
@@ -71,6 +80,36 @@ aarch64-apple-darwin:
 	mkdir -p release/$@
 	cp target/$@/release/motus release/$@/
 	tar czf release/motus-$@.tar.gz -C release/$@ motus
+
+# Rules for building headless Linux targets (no clipboard support)
+headless-x86_64-unknown-linux-gnu:
+	@echo "building headless for target x86_64-unknown-linux-gnu"
+	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-unknown-linux-gnu-gcc cross build --target x86_64-unknown-linux-gnu --release --no-default-features
+	mkdir -p release/headless-x86_64-unknown-linux-gnu
+	cp target/x86_64-unknown-linux-gnu/release/motus release/headless-x86_64-unknown-linux-gnu/
+	tar czf release/motus-headless-x86_64-unknown-linux-gnu.tar.gz -C release/headless-x86_64-unknown-linux-gnu motus
+
+headless-aarch64-unknown-linux-gnu:
+	@echo "building headless for target aarch64-unknown-linux-gnu"
+	cross build --target aarch64-unknown-linux-gnu --release --no-default-features
+	mkdir -p release/headless-aarch64-unknown-linux-gnu
+	cp target/aarch64-unknown-linux-gnu/release/motus release/headless-aarch64-unknown-linux-gnu/
+	tar czf release/motus-headless-aarch64-unknown-linux-gnu.tar.gz -C release/headless-aarch64-unknown-linux-gnu motus
+
+# Rules for building headless macOS targets (no clipboard support)
+headless-x86_64-apple-darwin:
+	@echo "building headless for target x86_64-apple-darwin"
+	cross build --target x86_64-apple-darwin --release --no-default-features
+	mkdir -p release/headless-x86_64-apple-darwin
+	cp target/x86_64-apple-darwin/release/motus release/headless-x86_64-apple-darwin/
+	tar czf release/motus-headless-x86_64-apple-darwin.tar.gz -C release/headless-x86_64-apple-darwin motus
+
+headless-aarch64-apple-darwin:
+	@echo "building headless for target aarch64-apple-darwin"
+	cargo build --target aarch64-apple-darwin --release --no-default-features
+	mkdir -p release/headless-aarch64-apple-darwin
+	cp target/aarch64-apple-darwin/release/motus release/headless-aarch64-apple-darwin/
+	tar czf release/motus-headless-aarch64-apple-darwin.tar.gz -C release/headless-aarch64-apple-darwin motus
 
 # Rule for creating a Debian package
 deb-%: check_deb
@@ -124,4 +163,4 @@ ifeq ($(shell uname),Darwin)
 	fi
 endif
 
-.PHONY: check_cross check_cargo check_toolchain check_deb check_rpm linux windows macos release $(LINUX_TARGETS) $(WINDOWS_TARGETS) $(MACOS_TARGETS) wasm deb rpm lint test ci-check
+.PHONY: check_cross check_cargo check_toolchain check_deb check_rpm linux windows macos release release-headless linux-headless macos-headless $(LINUX_TARGETS) $(WINDOWS_TARGETS) $(MACOS_TARGETS) $(addprefix headless-, $(LINUX_TARGETS)) $(addprefix headless-, $(MACOS_TARGETS)) wasm deb rpm

--- a/README.md
+++ b/README.md
@@ -63,8 +63,13 @@ apt install motus
 Alternatively, you can install using Cargo:
 
 ```bash
+# Install with clipboard support (default)
 cargo install motus
+
+# Install without clipboard support (for headless/server environments)
+cargo install motus --no-default-features
 ```
+
 
 ## Usage
 
@@ -157,13 +162,24 @@ UDrZrJJTYElWeOFHZmfp
 
 ### Clipboard Behavior
 
-In environments without X11/Wayland (such as SSH sessions, Docker containers, or headless servers), motus will generate passwords normally but cannot access the system clipboard. In these cases:
+For headless environments (SSH sessions, Docker containers, servers), you have two options:
+
+**Option 1: Compile without clipboard support (recommended for servers)**
+```bash
+# Install headless version with no clipboard dependencies
+cargo install motus --no-default-features
+
+# Use normally - no clipboard code or warnings
+motus memorable --words 5
+```
+
+**Option 2: Use runtime flag with standard version**
+In environments without X11/Wayland, the standard version will show warnings when clipboard access fails:
 
 - The password is still generated and displayed
 - A warning message is shown on stderr explaining the clipboard failure
 - Use `--no-clipboard` to suppress the warning for automated scripts
 
-**Example for SSH/headless environments:**
 ```bash
 # Suppress clipboard warnings for server usage
 motus --no-clipboard memorable --words 5

--- a/crates/motus-cli/Cargo.toml
+++ b/crates/motus-cli/Cargo.toml
@@ -4,6 +4,10 @@ name = "cli"
 version = "0.3.1"
 publish = false
 
+[features]
+default = ["clipboard"]
+clipboard = ["dep:arboard"]
+
 [[bin]]
 name = "motus"
 path = "src/main.rs"
@@ -16,15 +20,15 @@ Motus is a command-line application written in Rust that makes generating secure
 Inspired by the user experience of the 1Password password generator, motus focuses on providing a simple
 and elegant user interface with sane defaults and comprehensive options.
 
-By default, motus copies the generated password to your clipboard, making it even more convenient
-to use.
+By default, motus copies the generated password to your clipboard (when compiled with clipboard support),
+making it even more convenient to use.
 """
 maintainer = "Théo Crevon <theo@crevon.me>"
 priority = "optional"
 section = "main"
 
 [dependencies]
-arboard = { version = "3.2.0", default-features = false }
+arboard = { version = "3.2.0", default-features = false, optional = true }
 clap = "4.3.11"
 colored = "3.0.0"
 human-panic = { version = "2.0.2", default-features = false }

--- a/crates/motus-cli/src/main.rs
+++ b/crates/motus-cli/src/main.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
+#[cfg(feature = "clipboard")]
 use arboard::Clipboard;
 use clap::{Parser, Subcommand, ValueEnum};
 use colored::{ColoredString, Colorize};
@@ -27,6 +28,7 @@ struct Cli {
     command: Commands,
 
     /// Disable automatic copying of generated password to clipboard
+    #[cfg(feature = "clipboard")]
     #[arg(long)]
     no_clipboard: bool,
 
@@ -136,11 +138,15 @@ fn main() {
     };
 
     // Copy the password to the clipboard
-    if !opts.no_clipboard {
-        if let Err(e) = Clipboard::new().and_then(|mut clipboard| clipboard.set_text(&password)) {
-            eprintln!(
-                "Warning: Could not copy to clipboard: {e}. Use --no-clipboard to suppress this warning."
-            );
+    #[cfg(feature = "clipboard")]
+    {
+        if !opts.no_clipboard {
+            if let Err(e) = Clipboard::new().and_then(|mut clipboard| clipboard.set_text(&password))
+            {
+                eprintln!(
+                    "Warning: Could not copy to clipboard: {e}. Use --no-clipboard to suppress this warning."
+                );
+            }
         }
     }
 

--- a/crates/motus-cli/tests/integration.rs
+++ b/crates/motus-cli/tests/integration.rs
@@ -1,14 +1,24 @@
 use assert_cmd::Command;
 
-#[test]
-fn test_memorable_command_default_behavior() {
+// Helper function to create a command with appropriate clipboard flags
+fn motus_command() -> Command {
     let mut cmd = Command::cargo_bin("motus").unwrap();
 
+    // Only add --no-clipboard if the clipboard feature is enabled
+    #[cfg(feature = "clipboard")]
+    cmd.arg("--no-clipboard");
+
+    cmd
+}
+
+#[test]
+fn test_memorable_command_default_behavior() {
+    let mut cmd = motus_command();
+
     // `motus --seed 42 memorable`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("memorable")
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("memorable")
         .assert()
         .success()
         .stdout("chokehold nativity dolly ominous throat\n");
@@ -16,15 +26,14 @@ fn test_memorable_command_default_behavior() {
 
 #[test]
 fn test_memorable_command_custom_word_count() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 memorable --words 7`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("memorable")
-        .arg("--words")
-        .arg("7")
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("memorable");
+    cmd.arg("--words");
+    cmd.arg("7")
         .assert()
         .success()
         .stdout("chokehold native dollop omen thrive pungent woozy\n");
@@ -32,15 +41,14 @@ fn test_memorable_command_custom_word_count() {
 
 #[test]
 fn test_memorable_command_custom_separator() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 memorable --separator " "`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("memorable")
-        .arg("--separator")
-        .arg("numbers-and-symbols")
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("memorable");
+    cmd.arg("--separator");
+    cmd.arg("numbers-and-symbols")
         .assert()
         .success()
         .stdout("chokehold2nativity9dolly(ominous9throat\n");
@@ -48,14 +56,13 @@ fn test_memorable_command_custom_separator() {
 
 #[test]
 fn test_memorable_command_capitalize() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 memorable --capitalize`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("memorable")
-        .arg("--capitalize")
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("memorable");
+    cmd.arg("--capitalize")
         .assert()
         .success()
         .stdout("Chokehold Nativity Dolly Ominous Throat\n");
@@ -63,14 +70,13 @@ fn test_memorable_command_capitalize() {
 
 #[test]
 fn test_memorable_command_no_full_words() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 memorable --no-full-words`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("memorable")
-        .arg("--no-full-words")
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("memorable");
+    cmd.arg("--no-full-words")
         .assert()
         .success()
         .stdout("edhhookcl tyaitniv dlloy mnosiuo htator\n");
@@ -78,19 +84,18 @@ fn test_memorable_command_no_full_words() {
 
 #[test]
 fn test_memorable_command_all_options() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 memorable --words 7 --separator numbers-and-symbols --capitalize --no-full-words`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("memorable")
-        .arg("--words")
-        .arg("7")
-        .arg("--separator")
-        .arg("numbers-and-symbols")
-        .arg("--capitalize")
-        .arg("--no-full-words")
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("memorable");
+    cmd.arg("--words");
+    cmd.arg("7");
+    cmd.arg("--separator");
+    cmd.arg("numbers-and-symbols");
+    cmd.arg("--capitalize");
+    cmd.arg("--no-full-words")
         .assert()
         .success()
         .stdout("Lhkheoodc6Aivnte2Odopll#Mnoe)Thervi!Npetnug6Yzowo\n");
@@ -98,63 +103,52 @@ fn test_memorable_command_all_options() {
 
 #[test]
 fn test_memorable_command_too_little_words() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 memorable --words 2`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("memorable")
-        .arg("--words")
-        .arg("2")
-        .assert()
-        .failure();
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("memorable");
+    cmd.arg("--words");
+    cmd.arg("2").assert().failure();
 }
 
 #[test]
 fn test_memorable_command_too_many_words() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 memorable --words 16`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("memorable")
-        .arg("--words")
-        .arg("16")
-        .assert()
-        .failure();
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("memorable");
+    cmd.arg("--words");
+    cmd.arg("16").assert().failure();
 }
 
 #[test]
 fn test_memorable_command_unknown_separator() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 memorable --separator "foo"`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("memorable")
-        .arg("--separator")
-        .arg("foo")
-        .assert()
-        .failure();
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("memorable");
+    cmd.arg("--separator");
+    cmd.arg("foo").assert().failure();
 }
 
 #[test]
 fn test_memorable_command_json_output() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // motus --seed 42 memorable
-    let output = cmd
-        .arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("--output")
-        .arg("json")
-        .arg("memorable")
-        .output()
-        .expect("failed to execute process");
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("--output");
+    cmd.arg("json");
+    cmd.arg("memorable");
+
+    let output = cmd.output().expect("failed to execute process");
 
     let json = String::from_utf8(output.stdout)
         .expect("unable to parse json output; reason: invalid utf-8");
@@ -169,19 +163,17 @@ fn test_memorable_command_json_output() {
 
 #[test]
 fn test_memorable_command_analyze_json_output() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // motus --seed 42 memorable
-    let output = cmd
-        .arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("--analyze")
-        .arg("--output")
-        .arg("json")
-        .arg("memorable")
-        .output()
-        .expect("failed to execute process");
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("--analyze");
+    cmd.arg("--output");
+    cmd.arg("json");
+    cmd.arg("memorable");
+
+    let output = cmd.output().expect("failed to execute process");
 
     let json = String::from_utf8(output.stdout)
         .expect("unable to parse json output; reason: invalid utf-8");
@@ -207,13 +199,12 @@ fn test_memorable_command_analyze_json_output() {
 
 #[test]
 fn test_random_command_default_behavior() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 random`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("random")
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("random")
         .assert()
         .success()
         .stdout("BCHvbvMSgaWAuhBlaBcH\n");
@@ -221,30 +212,25 @@ fn test_random_command_default_behavior() {
 
 #[test]
 fn test_random_command_specified_characters_count() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 random --characters 10`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("random")
-        .arg("--characters")
-        .arg("10")
-        .assert()
-        .success()
-        .stdout("BCHvbvMSga\n");
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("random");
+    cmd.arg("--characters");
+    cmd.arg("10").assert().success().stdout("BCHvbvMSga\n");
 }
 
 #[test]
 fn test_random_command_numbers() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 random --numbers`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("random")
-        .arg("--numbers")
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("random");
+    cmd.arg("--numbers")
         .assert()
         .success()
         .stdout("BC640vMSga9A3h52aBcH\n");
@@ -252,14 +238,13 @@ fn test_random_command_numbers() {
 
 #[test]
 fn test_random_command_symbols() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 random --symbols`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("random")
-        .arg("--symbols")
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("random");
+    cmd.arg("--symbols")
         .assert()
         .success()
         .stdout("BC&%!vMSga)A$h^#aBcH\n");
@@ -267,17 +252,16 @@ fn test_random_command_symbols() {
 
 #[test]
 fn test_random_command_all_options() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 random --characters 10 --numbers --symbols`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("random")
-        .arg("--characters")
-        .arg("10")
-        .arg("--numbers")
-        .arg("--symbols")
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("random");
+    cmd.arg("--characters");
+    cmd.arg("10");
+    cmd.arg("--numbers");
+    cmd.arg("--symbols")
         .assert()
         .success()
         .stdout("BC6%!vMSga\n");
@@ -285,48 +269,40 @@ fn test_random_command_all_options() {
 
 #[test]
 fn test_random_command_too_little_characters() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 random --characters 2`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("random")
-        .arg("--characters")
-        .arg("2")
-        .assert()
-        .failure();
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("random");
+    cmd.arg("--characters");
+    cmd.arg("2").assert().failure();
 }
 
 #[test]
 fn test_random_command_too_many_characters() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 random --characters 101`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("random")
-        .arg("--characters")
-        .arg("101")
-        .assert()
-        .failure();
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("random");
+    cmd.arg("--characters");
+    cmd.arg("101").assert().failure();
 }
 
 #[test]
 fn test_random_command_json_output() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // motus --seed 42 memorable
-    let output = cmd
-        .arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("--output")
-        .arg("json")
-        .arg("random")
-        .output()
-        .expect("failed to execute process");
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("--output");
+    cmd.arg("json");
+    cmd.arg("random");
+
+    let output = cmd.output().expect("failed to execute process");
 
     let json = String::from_utf8(output.stdout)
         .expect("unable to parse json output; reason: invalid utf-8");
@@ -341,19 +317,17 @@ fn test_random_command_json_output() {
 
 #[test]
 fn test_random_command_analyze_json_output() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // motus --seed 42 memorable
-    let output = cmd
-        .arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("--analyze")
-        .arg("--output")
-        .arg("json")
-        .arg("random")
-        .output()
-        .expect("failed to execute process");
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("--analyze");
+    cmd.arg("--output");
+    cmd.arg("json");
+    cmd.arg("random");
+
+    let output = cmd.output().expect("failed to execute process");
 
     let json = String::from_utf8(output.stdout)
         .expect("unable to parse json output; reason: invalid utf-8");
@@ -378,78 +352,62 @@ fn test_random_command_analyze_json_output() {
 
 #[test]
 fn test_pin_command_default_behavior() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 pin`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("pin")
-        .assert()
-        .success()
-        .stdout("1525869\n");
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("pin").assert().success().stdout("1525869\n");
 }
 
 #[test]
 fn test_pin_command_numbers() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 pin --numbers`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("pin")
-        .arg("--numbers")
-        .arg("9")
-        .assert()
-        .success()
-        .stdout("152586949\n");
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("pin");
+    cmd.arg("--numbers");
+    cmd.arg("9").assert().success().stdout("152586949\n");
 }
 
 #[test]
 fn test_pin_command_too_little_numbers() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 pin --numbers 2`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("pin")
-        .arg("--numbers")
-        .arg("2")
-        .assert()
-        .failure();
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("pin");
+    cmd.arg("--numbers");
+    cmd.arg("2").assert().failure();
 }
 
 #[test]
 fn test_pin_command_too_many_numbers() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // `motus --seed 42 pin --numbers 9`
-    cmd.arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("pin")
-        .arg("--numbers")
-        .arg("13")
-        .assert()
-        .failure();
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("pin");
+    cmd.arg("--numbers");
+    cmd.arg("13").assert().failure();
 }
 
 #[test]
 fn test_pin_command_json_output() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // motus --seed 42 memorable
-    let output = cmd
-        .arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("--output")
-        .arg("json")
-        .arg("pin")
-        .output()
-        .expect("failed to execute process");
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("--output");
+    cmd.arg("json");
+    cmd.arg("pin");
+
+    let output = cmd.output().expect("failed to execute process");
 
     let json = String::from_utf8(output.stdout)
         .expect("unable to parse json output; reason: invalid utf-8");
@@ -464,19 +422,17 @@ fn test_pin_command_json_output() {
 
 #[test]
 fn test_pin_command_analyze_json_output() {
-    let mut cmd = Command::cargo_bin("motus").unwrap();
+    let mut cmd = motus_command();
 
     // motus --seed 42 memorable
-    let output = cmd
-        .arg("--no-clipboard")
-        .arg("--seed")
-        .arg("42")
-        .arg("--analyze")
-        .arg("--output")
-        .arg("json")
-        .arg("pin")
-        .output()
-        .expect("failed to execute process");
+    cmd.arg("--seed");
+    cmd.arg("42");
+    cmd.arg("--analyze");
+    cmd.arg("--output");
+    cmd.arg("json");
+    cmd.arg("pin");
+
+    let output = cmd.output().expect("failed to execute process");
 
     let json = String::from_utf8(output.stdout)
         .expect("unable to parse json output; reason: invalid utf-8");


### PR DESCRIPTION
This pull request introduces support for a "headless" mode in the `motus` CLI tool, which disables clipboard functionality for environments where clipboard access is unavailable or unnecessary (e.g., servers, SSH sessions). It also includes updates to the build system, documentation, and tests to accommodate this new feature.

### Build system updates:
* Added new Makefile rules for building "headless" versions of the application for Linux and macOS targets, which exclude clipboard support (`release-headless`, `linux-headless`, and `macos-headless`). [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R28-R42) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R84-R113)
* Updated `.PHONY` targets in the Makefile to include headless build rules.

### Feature implementation:
* Introduced a new `clipboard` feature in `Cargo.toml`, enabled by default, which can be disabled to exclude clipboard functionality. [[1]](diffhunk://#diff-026c99eab0e84a30c7110bad8941db9cdbf8b12ceec02de316af4b0cb2ea9e68R7-R10) [[2]](diffhunk://#diff-026c99eab0e84a30c7110bad8941db9cdbf8b12ceec02de316af4b0cb2ea9e68L19-R31)
* Updated `main.rs` to conditionally compile clipboard-related code based on the `clipboard` feature and to handle clipboard errors gracefully with warnings. [[1]](diffhunk://#diff-b126b00ea3789e5e62dda62b1c23e8d8bfe7ef4b70000537514ad71d790c1e68R4) [[2]](diffhunk://#diff-b126b00ea3789e5e62dda62b1c23e8d8bfe7ef4b70000537514ad71d790c1e68R31) [[3]](diffhunk://#diff-b126b00ea3789e5e62dda62b1c23e8d8bfe7ef4b70000537514ad71d790c1e68R141-R147)

### Documentation updates:
* Updated the `README.md` to explain the headless mode, including installation instructions with `--no-default-features` and usage examples for headless environments. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R66-R73) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R161-R208)

### Test updates:
* Refactored integration tests to use a helper function that conditionally adds the `--no-clipboard` flag based on the `clipboard` feature, ensuring tests work seamlessly in both modes. [[1]](diffhunk://#diff-d2ca7d032c8ca2117bc48612380f69a9b33f16210802e43d39390338d6a22708R3-R157) [[2]](diffhunk://#diff-d2ca7d032c8ca2117bc48612380f69a9b33f16210802e43d39390338d6a22708L172-R183) [[3]](diffhunk://#diff-d2ca7d032c8ca2117bc48612380f69a9b33f16210802e43d39390338d6a22708L381-R437)