### PR TITLE
fix: emit warning in context with no clipboard available

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,43 @@ UDrZrJJTYElWeOFHZmfp
 {"kind": "memorable", "password": "6HdwMjKQPYE3scIBlCps&1Ir5R8lQ85eIVtF!fpUSD"}
 ```
 
+## Headless and SSH Usage
+
+### Clipboard Behavior
+
+In environments without X11/Wayland (such as SSH sessions, Docker containers, or headless servers), motus will generate passwords normally but cannot access the system clipboard. In these cases:
+
+- The password is still generated and displayed
+- A warning message is shown on stderr explaining the clipboard failure
+- Use `--no-clipboard` to suppress the warning for automated scripts
+
+**Example for SSH/headless environments:**
+```bash
+# Suppress clipboard warnings for server usage
+motus --no-clipboard memorable --words 5
+```
+
+### Output Streams
+
+Motus follows Unix conventions for output streams:
+- **stdout**: Contains only the generated password (or JSON output)
+- **stderr**: Contains warnings and error messages
+
+This design ensures passwords can be reliably captured by scripts even when warnings occur.
+
+**Script usage example:**
+```bash
+#!/bin/bash
+# Capture password to variable, ignore clipboard warnings
+PASSWORD=$(motus memorable --words 4 2>/dev/null)
+
+# Or capture warnings separately for logging
+motus memorable --words 4 2>warnings.log | some-other-tool
+
+# Pipe password directly to other tools
+motus --no-clipboard random --characters 20 | pbcopy
+```
+
 ## Contributing
 
 We welcome contributions to the project. Feel free to submit issues, suggest new features, or create pull requests to help improve motus.

--- a/crates/motus-cli/src/main.rs
+++ b/crates/motus-cli/src/main.rs
@@ -137,11 +137,9 @@ fn main() {
 
     // Copy the password to the clipboard
     if !opts.no_clipboard {
-        let mut clipboard =
-            Clipboard::new().expect("unable to interact with your system's clipboard");
-        clipboard
-            .set_text(&password)
-            .expect("unable to set clipboard contents");
+        if let Err(e) = Clipboard::new().and_then(|mut clipboard| clipboard.set_text(&password)) {
+            eprintln!("Warning: Could not copy to clipboard: {}. Use --no-clipboard to suppress this warning.", e);
+        }
     }
 
     match opts.output {


### PR DESCRIPTION
This pull request introduces enhancements to the `motus` CLI tool, focusing on improving usability in headless and SSH environments and refining clipboard error handling. The changes ensure better user experience and script compatibility when system clipboard access is unavailable.

fixes #12 #5 

### Documentation Updates for Headless and SSH Usage:
- **`README.md`**: Added a new section explaining clipboard behavior in headless environments (e.g., SSH sessions, Docker containers). It includes examples for suppressing clipboard warnings and demonstrates proper usage of output streams (`stdout` and `stderr`) for scripting.

### Improved Clipboard Error Handling:
- **`crates/motus-cli/src/main.rs`**: Updated clipboard handling logic to gracefully handle errors. If clipboard access fails, a warning message is displayed on `stderr`, and users are advised to use the `--no-clipboard` flag to suppress the warning.