### PR TITLE
Fix Debian/Ubuntu Linux installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ gpg --dearmor | \
 sudo tee /usr/share/keyrings/oleiade-archive-keyring.gpg > /dev/null
 
 # Add the repository to your system's sources
-echo "deb [signed-by=/usr/share/keyrings/oleiade-archive-keyring.gpg] https://oleiade.github.io/deb stable main" \
+echo "deb [signed-by=/usr/share/keyrings/oleiade-archive-keyring.gpg] https://oleiade.github.io/deb stable main" | \
 sudo tee /etc/apt/sources.list.d/oleiade.list > /dev/null
 
 # Update your sources
-apt update
+sudo apt update
 
 # Install motus
-apt install motus
+sudo apt install motus
 ```
 
 ### using Cargo


### PR DESCRIPTION
The Debian/Ubuntu Linux installation script is missing a pipe and sudo operator. The sudo is obvious, but the pipe is a bit subtle to notice for those not familiar with Linux and just copy the instruction directly.

Closes #49 