### PR TITLE
fix: restore build after rand 0.10 upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,6 +960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]

--- a/crates/motus-cli/Cargo.toml
+++ b/crates/motus-cli/Cargo.toml
@@ -35,7 +35,7 @@ colored = "3.0.0"
 human-panic = { version = "2.0.2", default-features = false }
 motus = { path = "../motus" }
 rand = { version = "0.10.0", default-features = false, features = [ "alloc", "thread_rng" ] }
-serde = { version = "1.0.171", default-features = false }
+serde = { version = "1.0.171", default-features = false, features = ["derive"] }
 serde_json = "1.0.100"
 term-table = "1.4.0"
 zxcvbn = { version = "3.1.0", default-features = false }

--- a/crates/motus-cli/src/main.rs
+++ b/crates/motus-cli/src/main.rs
@@ -111,7 +111,7 @@ fn main() {
     // Initialize the randomness source
     // If a seed is provided, use it to seed the randomness source
     // Otherwise, use the main thread's randomness source
-    let mut rng: Box<dyn RngCore> = match opts.seed {
+    let mut rng: Box<dyn Rng> = match opts.seed {
         Some(seed) => Box::new(StdRng::seed_from_u64(seed)),
         None => Box::new(thread_rng()),
     };

--- a/crates/motus/src/lib.rs
+++ b/crates/motus/src/lib.rs
@@ -35,10 +35,10 @@ static WORDS_LIST: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
 /// # Example
 ///
 /// ```
-/// use rand::thread_rng;
+/// use rand::rng;
 /// use motus::{Separator, memorable_password};
 ///
-/// let rng = &mut thread_rng();
+/// let rng = &mut rng();
 /// let word_count = 3;
 /// let separator = Separator::Hyphen;
 /// let capitalize = true;
@@ -168,10 +168,10 @@ pub enum Separator {
 /// # Examples
 ///
 /// ```
-/// use rand::thread_rng;
+/// use rand::rng;
 /// use motus::random_password;
 ///
-/// let mut rng = thread_rng();
+/// let mut rng = rng();
 /// let password = random_password(&mut rng, 12, true, true);
 /// assert_eq!(password.len(), 12);
 /// ```
@@ -236,10 +236,10 @@ pub fn random_password<R: Rng>(
 /// # Examples
 ///
 /// ```
-/// use rand::thread_rng;
+/// use rand::rng;
 /// use motus::pin_password;
 ///
-/// let mut rng = thread_rng();
+/// let mut rng = rng();
 /// let pin = pin_password(&mut rng, 4);
 /// assert_eq!(pin.len(), 4);
 /// assert!(pin.chars().all(|c| c.is_digit(10)));
@@ -265,7 +265,7 @@ const SYMBOL_CHARS: &[char] = &['!', '@', '#', '$', '%', '^', '&', '*', '(', ')'
 
 // get_random_words returns a vector of n random words from the word list
 fn get_random_words<R: Rng>(rng: &mut R, n: usize) -> Vec<&'static str> {
-    WORDS_LIST.choose_multiple(rng, n).copied().collect()
+    WORDS_LIST.sample(rng, n).copied().collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`cargo build` was failing in `motus-cli` and emitted a deprecation warning in `motus`. All issues are mechanical fallout from the `rand` 0.10 upgrade in c89cafe, plus a missing `serde` feature flag in `motus-cli`.

## Changes

- **`crates/motus/src/lib.rs`** — `IndexedRandom::choose_multiple` was renamed to `sample` in `rand` 0.10; updated the call in `get_random_words`.
- **`crates/motus/src/lib.rs`** (doctests) — `rand::thread_rng` was renamed to `rand::rng` in 0.10; updated the three public doctests so `cargo test --doc` compiles.
- **`crates/motus-cli/src/main.rs`** — `rand::prelude` no longer re-exports `RngCore` and the trait is now deprecated in favour of `Rng`; switched `Box<dyn RngCore>` to `Box<dyn Rng>` (already in scope via `rand::prelude::*`).
- **`crates/motus-cli/Cargo.toml`** — added `features = ["derive"]` to the `serde` dep so `#[derive(Serialize)]` (`PasswordOutput`, `PasswordKind`) and `#[serde(...)]` attributes resolve. The crate had `default-features = false` with no features, so the derive macro and attribute were never available.
- **`Cargo.lock`** — refreshed for the new `serde_derive` transitive dependency.

## Test plan

- [x] `cargo build` — clean, no warnings, no errors
- [x] `cargo clippy --all-targets` — clean (the `motus` crate has `pedantic` and `nursery` set to `deny`)
- [x] `cargo test` — all unit tests and doctests pass
- [x] `cargo run -p cli -- memorable` — prints a memorable password
- [x] `cargo run -p cli -- --output json --analyze random` — produces well-formed JSON exercising both derived and manual `Serialize` impls
- [x] `cargo run -p cli -- --seed 42 pin` — exercises the `Box<dyn Rng>` seeded path

🤖 Generated with [Claude Code](https://claude.com/claude-code)