### PR TITLE
style: drop a redundant reference in a format! argument

### DIFF
--- a/crates/motus-cli/src/main.rs
+++ b/crates/motus-cli/src/main.rs
@@ -387,7 +387,7 @@ impl Serialize for SecurityAnalysis<'_> {
         )?;
         struct_serializer.serialize_field(
             "guesses",
-            format!("10^{:.0}", &self.entropy.guesses_log10()).as_str(),
+            format!("10^{:.0}", self.entropy.guesses_log10()).as_str(),
         )?;
         struct_serializer.serialize_field("crack_times", &crack_times)?;
         struct_serializer.end()


### PR DESCRIPTION
## Summary
- A newer stable clippy flags `&self.entropy.guesses_log10()` in `format!` as an unnecessary reference (`clippy::useless_borrows_in_formatting`), which fails the `Formatting & Linting` CI job on `main` and on every PR based on it (e.g. #62).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)